### PR TITLE
A few fixes

### DIFF
--- a/src/pointcloud2_deskew.cpp
+++ b/src/pointcloud2_deskew.cpp
@@ -10,6 +10,7 @@
 PLUGINLIB_EXPORT_CLASS(PointCloud2Deskew, nodelet::Nodelet);
 
 ros::Publisher pub;
+ros::Subscriber sub;
 boost::shared_ptr<tf::TransformListener> tf_ptr;
 std::string fixed_frame_for_laser = "odom";  //TODO: Load as a parameter
 std::string time_field_name = "t";
@@ -129,15 +130,12 @@ void PointCloud2Deskew::onInit()
 {
     ros::NodeHandle nh;
 
-    // Create a ROS subscriber for the input point cloud
-    ros::Subscriber sub = nh.subscribe ("input_point_cloud", 20, cloud_callback);
-
     // Create a transform listener
     tf_ptr.reset(new tf::TransformListener);
 
     // Create a ROS publisher for the output point cloud
     pub = nh.advertise<sensor_msgs::PointCloud2> ("output_point_cloud", 20);
 
-    // Spin
-    ros::spin ();
+    // Create a ROS subscriber for the input point cloud
+    sub = nh.subscribe ("input_point_cloud", 20, cloud_callback);
 }

--- a/src/pointcloud2_deskew.cpp
+++ b/src/pointcloud2_deskew.cpp
@@ -22,7 +22,6 @@ void cloud_callback (const sensor_msgs::PointCloud2ConstPtr& input)
 {
 
     //Measure callback duration
-    std::cout << "Beginning processing pcl...  ";
     auto start = std::chrono::steady_clock::now();
 
     // Create a container for the data.
@@ -115,15 +114,14 @@ void cloud_callback (const sensor_msgs::PointCloud2ConstPtr& input)
 
 
     auto end = std::chrono::steady_clock::now();
-    std::cout << "... done." << std::endl;
-    std::cout << "Elapsed callback time in milliseconds : "
-         << std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count()
-         << " ms. ";
-    std::cout << "Elapsed callback time in waiting for transform: "
-              << std::chrono::duration_cast<std::chrono::milliseconds>(after_waitForTransform - start).count()
-              << " ms." << std::endl;
-    std::cout << "Number of tf's fetched: " << tfs_cache.size() << std::endl;
-
+    const auto cb_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+    if (cb_time_ms > 50)
+    {
+      const auto tf_time = std::chrono::duration_cast<std::chrono::milliseconds>(after_waitForTransform - start).count();
+      ROS_WARN_STREAM_THROTTLE(1.0, "Elapsed callback time in milliseconds : " << cb_time_ms << " ms. ");
+      ROS_WARN_STREAM_THROTTLE(1.0, "Elapsed callback time in waiting for transform: " << tf_time << " ms.");
+      ROS_WARN_STREAM_THROTTLE(1.0, "Number of tf's fetched: " << tfs_cache.size());
+    }
 }
 
 void PointCloud2Deskew::onInit()

--- a/src/pointcloud2_deskew.cpp
+++ b/src/pointcloud2_deskew.cpp
@@ -128,7 +128,7 @@ void cloud_callback (const sensor_msgs::PointCloud2ConstPtr& input)
 
 void PointCloud2Deskew::onInit()
 {
-    ros::NodeHandle nh;
+    ros::NodeHandle nh = this->getNodeHandle();
 
     // Create a transform listener
     tf_ptr.reset(new tf::TransformListener);

--- a/src/pointcloud2_deskew.cpp
+++ b/src/pointcloud2_deskew.cpp
@@ -19,6 +19,7 @@ uint32_t round_to_intervals_of_nanoseconds = 50000;
 double max_scan_duration = 0.5;
 uint32_t max_scan_columns = expected_number_of_pcl_columns;
 bool skip_invalid = false;
+double runtime_warn_threshold_ms = 80;
 
 
 void cloud_callback (const sensor_msgs::PointCloud2ConstPtr& input)
@@ -145,7 +146,7 @@ void cloud_callback (const sensor_msgs::PointCloud2ConstPtr& input)
 
     auto end = std::chrono::steady_clock::now();
     const auto cb_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
-    if (cb_time_ms > 50)
+    if (cb_time_ms > runtime_warn_threshold_ms)
     {
       const auto tf_time = std::chrono::duration_cast<std::chrono::milliseconds>(after_waitForTransform - start).count();
       ROS_WARN_STREAM_THROTTLE(1.0, "Elapsed callback time in milliseconds : " << cb_time_ms << " ms. ");
@@ -172,6 +173,7 @@ void PointCloud2Deskew::onInit()
     
     time_field_name = pnh.param("time_field_name", time_field_name);
     fixed_frame_for_laser = pnh.param("fixed_frame_for_laser", fixed_frame_for_laser);
+    runtime_warn_threshold_ms = pnh.param("runtime_warn_threshold_ms", runtime_warn_threshold_ms);
     
     // Create a ROS publisher for the output point cloud
     pub = nh.advertise<sensor_msgs::PointCloud2> ("output_point_cloud", 20);


### PR DESCRIPTION
I discovered and fixed a few problems when testing.

1. do not call `ros::spin()` in nodelets - the nodelet manager does that. The `onInit()` method is required to be (almost) non-blocking. If you ran the unfixed code with other nodelets, they would never initialize and run because they would indefinitly wait until this nodelet's `onInit()` finishes
2. first create all publishers and other class members/globals, and only then create the subscribers - as soon as they are created, they'll start firing callbacks, and if the other members are not yet initialized, you've got a problem
3. `sub` would go out of scope when the `ros::spin()` was removed, so I moved it to the global scope

I also misconfigured the lidar driver and got a cloud without the `t` field. The user experience was nice, though because there was an exception printed to the console telling me that there is no field `t` in the cloud. I think this is good behavior - much better than staying alive and pretending nothing is wrong.

Thanks for the patch, otherwise it looks good. Maybe you could remove/throttle the status prints. On our NUC, the deskewing adds about 10 ms processing time and takes 10-15% of one CPU core. And I haven't yet plugged it in the correct pipeline with other nodelets, so it will get even better.